### PR TITLE
Support Laravel 11–13 (drop 9/10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
         "laravel/prompts": "^0.1.18 || ^0.2.0 || ^0.3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0 || ^7.0 || ^8.0",
-        "orchestra/testbench": "^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "pestphp/pest": "^1.0 || ^2.0 || ^3.0",
-        "pestphp/pest-plugin-laravel": "^1.0 || ^2.0 || ^v3.0"
+        "nunomaduro/collision": "^8.0 || ^9.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^2.0 || ^3.0 || ^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0 || ^3.0 || ^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Adopts Laravel 11+ baseline: drops Laravel 9 and 10 from `illuminate/contracts`, keeps 12, adds 13
- Bumps `orchestra/testbench` (`^9.0|^10.0|^11.0`), `nunomaduro/collision` (`^8.0|^9.0`), `pestphp/pest` and `pestphp/pest-plugin-laravel` (each `^2.0|^3.0|^4.0`) to cover the new generations

## Test plan
- [ ] Confirm composer install resolves cleanly on Laravel 11, 12, and 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)